### PR TITLE
Have codepoints link to their own codepoints.net page

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <div></div>
 
   <footer>
-    <a id="github" href="https://github.com/ardislu/utf-8-visualizer">
+    <a class="icon-link" href="https://github.com/ardislu/utf-8-visualizer">
       <svg aria-labelledby="github" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <title id="github">GitHub repository</title>
         <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <div></div>
 
   <footer>
-    <a href="https://github.com/ardislu/utf-8-visualizer">
+    <a id="github" href="https://github.com/ardislu/utf-8-visualizer">
       <svg aria-labelledby="github" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <title id="github">GitHub repository</title>
         <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path>

--- a/script.js
+++ b/script.js
@@ -76,12 +76,12 @@ function render(output) {
 
   for (const item of output) {
     const viz = document.createElement('al-point-visualization');
-    viz.insertAdjacentHTML('beforeend', `<span slot="char">${item.char}</slot>`);
-    viz.insertAdjacentHTML('beforeend', `<span slot="point">${item.point}</slot>`);
+    viz.insertAdjacentHTML('beforeend', `<span slot="char">${item.char}</span>`);
+    viz.insertAdjacentHTML('beforeend', `<span slot="point"><a href="https://codepoints.net/${item.point}">${item.point}</a></span>`);
 
     const [pointBinary, bytes] = parseBytes(item.bytes);
-    viz.insertAdjacentHTML('beforeend', `<span slot="point-binary">${pointBinary}</slot>`);
-    viz.insertAdjacentHTML('beforeend', `<span slot="bytes">${bytes}</slot>`);
+    viz.insertAdjacentHTML('beforeend', `<span slot="point-binary">${pointBinary}</span>`);
+    viz.insertAdjacentHTML('beforeend', `<span slot="bytes">${bytes}</span>`);
 
     vizContainer.insertAdjacentElement('beforeend', viz);
   }

--- a/style.css
+++ b/style.css
@@ -59,7 +59,7 @@ a {
   text-decoration: inherit;
 }
 
-a#github {
+a.icon-link {
   line-height: 0;
   background: hsl(222deg 50% 30%);
   color: hsl(222deg 50% 95%);
@@ -68,19 +68,19 @@ a#github {
   transition: filter 800ms;
 }
 
-a#github:hover,
-a#github:focus-within {
+a.icon-link:hover,
+a.icon-link:focus-within {
   filter: brightness(120%) drop-shadow(0 0 4px hsl(222deg 50% 50%));
   transition: filter 400ms;
 }
 
-a#github>svg {
+a.icon-link>svg {
   inline-size: 24px;
   block-size: 24px;
   transition: transform 600ms;
 }
 
-:is(a#github:hover, a#github:focus-within)>svg {
+:is(a.icon-link:hover, a.icon-link:focus-within)>svg {
   transform: translateY(-2px);
   transition: transform 200ms;
 }

--- a/style.css
+++ b/style.css
@@ -55,6 +55,11 @@ div#visualizations {
 }
 
 a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+a#github {
   line-height: 0;
   background: hsl(222deg 50% 30%);
   color: hsl(222deg 50% 95%);
@@ -63,19 +68,19 @@ a {
   transition: filter 800ms;
 }
 
-a:hover,
-a:focus-within {
+a#github:hover,
+a#github:focus-within {
   filter: brightness(120%) drop-shadow(0 0 4px hsl(222deg 50% 50%));
   transition: filter 400ms;
 }
 
-a>svg {
+a#github>svg {
   inline-size: 24px;
   block-size: 24px;
   transition: transform 600ms;
 }
 
-:is(a:hover, a:focus-within)>svg {
+:is(a#github:hover, a#github:focus-within)>svg {
   transform: translateY(-2px);
   transition: transform 200ms;
 }

--- a/style.css
+++ b/style.css
@@ -85,6 +85,16 @@ a.icon-link>svg {
   transition: transform 200ms;
 }
 
+a:not(.icon-link) {
+  text-decoration: underline;
+  font-weight: 700;
+  color: hsl(222deg 80% 95% / 90%);
+}
+
+:is(a:not(.icon-link):hover, a:not(.icon-link):focus-within) {
+  text-decoration: none;
+}
+
 /* For the point binary */
 .shrink {
   display: inline-block;


### PR DESCRIPTION
Hey, I found your tool really useful and I want to link to it in a blogpost I'm writing. 

I realized that for my use-case the only thing that's missing in it are links for the codepoints, so that you can read what their intended role and history is. It's particularly useful for invisible characters, where you can't deduce their meaning from the visualization

So for example, if you click on `U+200D` on https://utf-8-visualizer.ardis.lu/ , it should bring you to  https://codepoints.net/U+200D , which explains what the zero width joiner is and why it's there.

---

I tried to fit in with the style of the project and not change too much. 

The one `</slot>` -> `</span>` change is a bugfix, I think. But given how late in the day it is and how weak my JavaScript knowledge is, I'm not sure :)
